### PR TITLE
Python3 compatibility

### DIFF
--- a/examples/0_cross_section.py
+++ b/examples/0_cross_section.py
@@ -30,7 +30,7 @@ if __name__ == '__main__':
             (1, 0, 1),
             (0, 0, 1)
         ]
-        print "num contours : ", len(P), ' expected : ', expected_n_contours
+        print("num contours : ", len(P), ' expected : ', expected_n_contours)
 
         if True:
             utils.trimesh3d(mesh.verts, mesh.tris, color=(1, 1, 1),

--- a/examples/1_stl_sphere_cut.py
+++ b/examples/1_stl_sphere_cut.py
@@ -50,7 +50,7 @@ if __name__ == '__main__':
             (1, 0, 1),
             (0, 0, 1)
         ]
-        print "num contours : ", len(P)
+        print("num contours : ", len(P))
 
         if True:
             utils.trimesh3d(mesh.verts, mesh.tris, color=(1, 1, 1),

--- a/meshcut.py
+++ b/meshcut.py
@@ -42,7 +42,7 @@ class TriangleMesh(object):
         # Fill data structures
         for tid, f in enumerate(tris):
             tri_edges = []
-            for i in xrange(3):
+            for i in range(3):
                 v1 = f[i]
                 v2 = f[(i + 1) % 3]
                 e = make_edge(v1, v2)


### PR DESCRIPTION
I changed `xrange()` and print parentheses in the examples. I ran the tests for Python2.7 and Python3.6, works without any errors/warnings.